### PR TITLE
Add dockerfile & instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi7:7.9
+LABEL author="William Jenkins <wjenkins@ucsd.edu>"
+RUN yum update -y
+RUN yum install -y gcc-gfortran gdb git make vim
+RUN git clone https://github.com/gerstoft/saga.git
+ENV SAGADIR=/saga
+ENV HOSTTYPE=x86_64
+ENV FORTRAN=gfortran
+COPY setup.sh $SAGADIR
+WORKDIR $SAGADIR
+RUN bash ./setup.sh
+WORKDIR $SAGADIR/src
+RUN make clean && make all
+WORKDIR $SAGADIR

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# Docker container for SAGA geoacoustic inversion software
+
+By [William Jenkins](https://github.com/NeptuneProjects)  
+21 November 2022
+
+SAGA and its required FORTRAN dependencies can be installed using Docker. This allows for portability and eliminates the need to install or alter libraries on your system directly.
+
+## Dockerfile
+
+The `Dockerfile` is used to build a container image. Its contents include:
+- Line 1: Specify Redhat’s Linux distribution to match the remote server we normally work on.
+- Line 3: Install the following packages: Fortran compiler `gcc-gfortran`, debugger `gdb`, `git` for version control, `make` to compile SAGA, and `vim` to edit files within the container environment.
+- Line 4: Clone the SAGA repository into the container.
+- Line 5: Specify the working directory for SAGA.
+- Line 6: Specify the host architecture.
+- Lines 7-13: Install SAGA using a setup script.
+
+## setup.sh
+
+The setup script is necessary to add the SAGA working and bin directories to the container’s system path.
+
+## Building the Docker container
+Here is a simple way to build the container image and run it:
+```bash
+docker build . -t IMAGENAME
+docker run -v /HOSTDIR:/saga IMAGENAME
+```
+`IMAGENAME` is the name of the container image, and `HOSTDIR` is the [local] directory you want to mount to the Docker image as a volume.

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# 
+# William Jenkins
+# Scripps Institution of Oceanography
+# 21 November 2022
+# 
+# Script works in concert with Dockerfile to add SAGA configuration to .bashrc.
+
+( echo "" ; echo "# >> Begin SAGA Configuration <<" ) >> ~/.bashrc
+echo "export FORTRAN=$FORTRAN" >> ~/.bashrc
+echo "export HOSTTYPE=$HOSTTYPE" >> ~/.bashrc
+echo "export PATH=$SAGADIR/bin:$SAGADIR/bin/$HOSTTYPE-$FORTRAN:$PATH" >> ~/.bashrc
+echo "# >> End SAGA Configuration <<" >> ~/.bashrc


### PR DESCRIPTION
Adding capability to install SAGA using Docker, instead of directly onto a machine. This should simplify installation and make the software more portable.